### PR TITLE
Allow kubeclient gem installation with puppet itself.

### DIFF
--- a/lib/puppet/feature/kubeclient.rb
+++ b/lib/puppet/feature/kubeclient.rb
@@ -1,0 +1,1 @@
+Puppet.features.add(:kubeclient, :libs => ["kubeclient"])


### PR DESCRIPTION
Without this change, compilation of the catalog fails where there is no
kubeclient. What is more, it is now possible both to install kubeclient
via puppet itself and deploy descriptors in a single puppet run. As a
side effect, puppet master no longer needs to have kubeclient library
installed.

Based on sensu-puppet,
http://alcy.github.io/2012/11/21/handling-gem-dependencies-in-custom-puppet-providers/

Some details:

1) require 'kubeclient' removed since it is done magically and *lazily*
upon provider evaluation via confine :feature => :kubeclient. See
https://projects.puppetlabs.com/issues/17747#note-8

2) require 'recursive_open_struct' removed and ensure_value_at_path
moved to provider itself since we don't want to require any external
libraries prematurely.

3) 'subclass.confine :feature => :kubeclient' is called on each provider
subclass.