### PR TITLE
Pin version of activesupport to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ running.
 
 Install the required gems with this command:
 
+    /opt/puppetlabs/puppet/bin/gem install activesupport -v 4.1.14
     /opt/puppetlabs/puppet/bin/gem install kubeclient --no-ri --no-rdoc
 
 #### Configuring credentials


### PR DESCRIPTION
The kubeclient gem does not specify what version of activesupport to install, and it's currently on 2.2 Ruby only:

ERROR:  Error installing kubeclient:
	activesupport requires Ruby version >= 2.2.2.

So we can specify an older version first