### PR TITLE
Removed the default namespace since not all objects are namespaced

### DIFF
--- a/lib/puppet_x/puppetlabs/kubernetes/provider.rb
+++ b/lib/puppet_x/puppetlabs/kubernetes/provider.rb
@@ -158,7 +158,7 @@ module PuppetX
           if self.metadata == :absent
             # This means the resource doesn't exist already
             if resource[:metadata]
-              resource[:metadata]['namespace'] || 'default'
+              resource[:metadata]['namespace']
             else
               # for resources without metadata like namespaces
               # we don't need to set a namespace


### PR DESCRIPTION
A fix for #19 to remove the default namespace assignment