### PR TITLE
Remove fixnumify function when creating the object

### DIFF
--- a/lib/puppet_x/puppetlabs/kubernetes/provider.rb
+++ b/lib/puppet_x/puppetlabs/kubernetes/provider.rb
@@ -76,7 +76,7 @@ module PuppetX
         def make_object(type, name, params)
           klass = type.split('_').collect(&:capitalize).join
           params[:metadata] = {} unless params.key?(:metadata)
-          p = params.swagger_symbolize_keys.fixnumify
+          p = params.swagger_symbolize_keys
           object = Object::const_get("Kubeclient::#{klass}").new(p)
           object.metadata.name = name
           object.metadata.namespace = namespace unless namespace.nil?


### PR DESCRIPTION
This fix should prevent the problem when creating an environment variable with an integer as value.
```Error: Could not set 'present' on ensure: HTTP status code 400, Deployment in version "v1beta1" cannot be handled as a Deployment: [pos 1937]: json: expect char '"' but got char '2' at ```

 It also mean that now, you must be careful when writing your manifests