### PR TITLE
Allow the updates of kubernetes resources (service annotations, etc ...)

### DIFF
--- a/lib/puppet_x/puppetlabs/kubernetes/provider.rb
+++ b/lib/puppet_x/puppetlabs/kubernetes/provider.rb
@@ -110,18 +110,24 @@ module PuppetX
             if value.respond_to? :each
               value.each do |inner_key,inner_value|
                 if [Fixnum, String].include? inner_value.class
-                  data << [[key,inner_key], inner_value.fixnumify]
+                  data << [[key,inner_key], inner_value]
                 end
                 if inner_value.class == Array
                   inner_value.each_with_index do |item,index|
                     item.each do |k,v|
-                      data << [[key, inner_key, index, k], v.fixnumify]
+                      data << [[key, inner_key, index, k], v]
                     end
+                  end
+                end
+                if inner_value.class == Hash
+                  applicator = build_applicator(inner_value)
+                  applicator.each do |k,v|
+                    data << [[key, inner_key, k].flatten, v]
                   end
                 end
               end
             else
-              data << [[key], value.fixnumify]
+              data << [[key], value]
             end
           end
           data


### PR DESCRIPTION
Since  some of kubernetes resources configuration are into puppet hashes, the changes weren't seen by the build_applicator.
I added the possibility to go into them and recurse in order to have an up to date object sent to kubernetes apiserver.

Should work with any kubernetes resources.

It only works if you add or update a resource. I need to find a good solution to remove a property from a resource.