### PR TITLE
latest kubeclient(3.0.0) breaks this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ running.
 Install the required gems with this command:
 
     /opt/puppetlabs/puppet/bin/gem install activesupport -v 4.1.14
-    /opt/puppetlabs/puppet/bin/gem install kubeclient --no-ri --no-rdoc
+    /opt/puppetlabs/puppet/bin/gem install kubeclient -v 2.5.2 --no-ri --no-rdoc
 
 #### Configuring credentials
 


### PR DESCRIPTION
The README.md specifies the version of kubeclient that works which is helpful for those following the readme.